### PR TITLE
Add MariaDb to dep list

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,20 @@
 Holds docker files for local and production development
 
 # Running dependencies locally
-`sudo docker-compose up`
+`docker-compose up`
 
 # Running a service image
-`sudo docker-compose -f docker-compose.ServiceName.yml - f docker-compose.yml up`
+`docker-compose -f docker-compose.ServiceName.yml - f docker-compose.yml up`
+
+# Common problems
+## Need Sudo to run these / could not connect to Docker service
+1. Ensure the current user is added to the docker group
+`sudo usermod -a -G docker $USER`
+2. Log out and back into session
+3. Run all docker commands without sudo
+
+## The MYSQL_ROOT_PASSWORD env variable is not set
+1. Ensure that you export the env. variable like so
+`export MYSQL_ROOT_PASSWORD=yourPass`
+2. If you are running it as root (see above, you shouldn't), you require the -E flag. For example
+`sudo -E docker-compose up`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,7 @@ services:
   syslog-ng:
     image : balabit/syslog-ng:latest
     hostname: syslog
-    restart: always
-    command: "--no-caps"
+    command: "--no-caps --foreground"
 
     cap_drop:
       - ALL
@@ -18,8 +17,24 @@ services:
     volumes:
       # Map custom config in
       - ./conf/syslog-ng.conf:/etc/syslog-ng/syslog-ng.conf
-      - ./mount/syslog-ng:/var/log/syslog
+      - ./mount/syslog-ng/log:/var/log
 
     ports:
       - "601:601"
       - "514:514"
+
+  maria-db:
+    image: mariadb:latest
+    hostname : mariadb
+
+    ports:
+      - "3306:3306"
+
+    volumes:
+      - ./mount/maria-db:/var/lib/mysql
+
+    # If a password is not present this will exit out
+    environment:
+      - MYSQL_ROOT_PASSWORD
+      # For testing you could also use the followig line
+      # - MYSQL_ROOT_PASSWORD=your_pass


### PR DESCRIPTION
Adds MariaDB to our dep list and sets it up to be persistent (in the mount directory of the git repo)

To run this microservice you must `export MYSQL_ROOT_PASSWORD=pass` where pass is of your choosing